### PR TITLE
pvrexa: Implement LRU list of BO mappings

### DIFF
--- a/src/omap_exa_pvr.h
+++ b/src/omap_exa_pvr.h
@@ -40,11 +40,15 @@ typedef struct PVR
 	ExaDriverPtr exa;
 	PPVRSERVICES srv;
 	void *scanout_priv;
+	/* LRU BO maps */
+	struct xorg_list map_list;
+	unsigned long map_count;
 } PVRRec, *PVRPtr;
 
 typedef struct PrivPixmap
 {
 	PVR2DMEMINFO meminfo;
+	struct xorg_list map;
 } PrivPixmapRec, *PrivPixmapPtr;
 
 typedef enum


### PR DESCRIPTION
Do not keep all BO mappings, just N last recently used. Fixes high file handles usage count eventually leading to server crash when system limit is hit.

Signed-off-by: Ivaylo Dimitrov <ivo.g.dimitrov.75@gmail.com>